### PR TITLE
Lazygit and Gitblame plugins added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+lazy-lock.json

--- a/README.md
+++ b/README.md
@@ -3,18 +3,38 @@ NeoVim Configuration V2 (Late 2024) strong based on Josean Martinez video tutori
 
 https://www.youtube.com/watch?v=6pAG3BHurdM&t=4190s (kudos!)
 
+## Quick Start
+
+```shell
+$ mkdir .config
+$ cd .config
+$ git clone git@github.com:Legrandk/neovim_config_v2.git
+$ ln -s neovim_config_v2 nvim
+```
+
 ## Installed Plugins
 
 - Autopairs
 - Colorscheme
 - Dressing
+- GitBlame
 - Indent-Blankline
+- LazyGit
 - Lualine
 - Nvim-Cmp
 - Nvim-Tree
 - Treesitter
 - Vim-Maximizer
 - Which-key
+
+## Main Treesitter Language Parsers
+
+- Elixir
+- Go
+- Javascript
+- Kotlin
+- Python
+- Ruby
 
 ## LSP Servers
 
@@ -23,3 +43,4 @@ https://www.youtube.com/watch?v=6pAG3BHurdM&t=4190s (kudos!)
 - Kotlin
 - LuaLs
 - Solargraph
+

--- a/lua/alex/core/keymaps.lua
+++ b/lua/alex/core/keymaps.lua
@@ -37,3 +37,9 @@ keymap.set("n", "<leader>fb", "<cmd>Telescope buffers<CR>", { desc = "Find strin
 
 -- Vim Maximizer
 keymap.set("n", "<leader>sm", "<cmd>MaximizerToggle<CR>", { desc = "Maximize/minimize a split" })
+
+-- LazyGit
+keymap.set("n", "<leader>lg", "<cmd>LazyGit<CR>", { desc = "LazyGit" })
+
+-- GitBlame
+keymap.set("n", "<leader>gO", "<cmd>GitBlameOpenCommitURL<CR>", { desc = "Open commit url on Github" })

--- a/lua/alex/plugins/git-blame.lua
+++ b/lua/alex/plugins/git-blame.lua
@@ -1,0 +1,15 @@
+return {
+  "f-person/git-blame.nvim",
+  -- load the plugin at startup
+  event = "VeryLazy",
+  -- Because of the keys part, you will be lazy loading this plugin.
+  -- The plugin wil only load once one of the keys is used.
+  -- If you want to load the plugin at startup, add something like event = "VeryLazy",
+  -- or lazy = false. One of both options will work.
+  opts = {
+    enabled = true,
+    message_template = " <author> • <date> • <<sha>>",
+    date_format = "%m-%d-%Y %H:%M",
+    virtual_text_column = 80,
+  },
+}

--- a/lua/alex/plugins/lazygit.lua
+++ b/lua/alex/plugins/lazygit.lua
@@ -1,0 +1,7 @@
+return {
+  "kdheepak/lazygit.nvim",
+  -- optional for floating window border decoration
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+  },
+}

--- a/lua/alex/plugins/treesitter.lua
+++ b/lua/alex/plugins/treesitter.lua
@@ -39,6 +39,7 @@ return {
         "lua",
         "markdown",
         "markdown_inline",
+        "python",
         "ruby",
         "sql",
         "typescript",


### PR DESCRIPTION
This PR adds the following plugins:

- Lazygit (https://github.com/kdheepak/lazygit.nvim)
- GitBlame (https://github.com/f-person/git-blame.nvim)

Besides we updated the `.gitignore` to discount the `lazy-lock.json`.