### PR TITLE
(New) Telescope Multigrep Addon

### DIFF
--- a/lua/alex/core/keymaps.lua
+++ b/lua/alex/core/keymaps.lua
@@ -29,9 +29,11 @@ keymap.set("n", "<leader>ef", "<cmd>NvimTreeFindFileToggle<CR>", { desc = "Toggl
 keymap.set("n", "<leader>er", "<cmd>NvimTreeRefresh<CR>", { desc = "Refresh file explorer" })
 
 -- Telescope
+keymap.set("n", "<leader>fh", "<cmd>Telescope help_tags<CR>", { desc = "Telescope help tags" })
 keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<CR>", { desc = "Fuzzy find files in cwd" })
 keymap.set("n", "<leader>fr", "<cmd>Telescope oldfiles<CR>", { desc = "Fuzzy find recent files" })
-keymap.set("n", "<leader>fg", "<cmd>Telescope live_grep<CR>", { desc = "Find string in cwd" })
+-- NOTE: Configured in telescope/multigrep.lua
+-- keymap.set("n", "<leader>fg", "<cmd>Telescope live_grep<CR>", { desc = "Find string in cwd" })
 keymap.set("n", "<leader>fc", "<cmd>Telescope grep_string<CR>", { desc = "Find string under cursor in cwd" })
 keymap.set("n", "<leader>fb", "<cmd>Telescope buffers<CR>", { desc = "Find string in buffers" })
 
@@ -47,3 +49,11 @@ keymap.set("n", "<leader>gO", "<cmd>GitBlameOpenCommitURL<CR>", { desc = "Open c
 -- Marks (aka Bookmarks)
 keymap.set("n", "<leader>ml", "<cmd>marks<CR>", { desc = "Show list of bookmarks" })
 keymap.set("n", "<leader>mD", "<cmd>delmarks a-zA-Z0-9<CR>", { desc = "Show list of bookmarks" })
+
+-- Oil (File explorer within buffers)
+keymap.set("n", "<leader>eo", "<cmd>Oil<CR>", { desc = "Open parent directory (Oil)" })
+
+-- Lua Development
+keymap.set("n", "<leader><space>x", "<cmd>source %<CR>", { desc = "Source current file" })
+keymap.set("n", "<leader>x", "<cmd>:.lua<CR>", { desc = "Execute current lua line code" })
+keymap.set("v", "<leader>x", "<cmd>:lua<CR>", { desc = "Execute current lua block code" })

--- a/lua/alex/plugins/telescope.lua
+++ b/lua/alex/plugins/telescope.lua
@@ -21,9 +21,14 @@ return {
             ["<C-q>"] = actions.send_selected_to_qflist + actions.open_qflist, -- move to prev result
           },
         },
+        extensions = {
+          fzf = {},
+        }
       },
     })
 
     telescope.load_extension("fzf")
+
+    require("alex.plugins.telescope.multigrep").setup()
   end,
 }

--- a/lua/alex/plugins/telescope/multigrep.lua
+++ b/lua/alex/plugins/telescope/multigrep.lua
@@ -1,0 +1,58 @@
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local make_entry = require("telescope.make_entry")
+local config = require("telescope.config").values
+
+local M = {}
+
+local live_multigrep = function(opts)
+  opts = opts or {}
+  opts.cwd = opts.cwd or vim.uv.cwd()
+
+  local finder = finders.new_async_job {
+    command_generator = function(prompt)
+      if not prompt or prompt == "" then
+        return nil
+      end
+
+      local args = { "rg" }
+
+      local idx = vim.fn.stridx(prompt, "  ")
+
+      table.insert(args, "-e")
+      table.insert(args, string.sub(prompt, 1, idx))
+
+      if idx > -1 then
+        local globs = string.sub(prompt, idx + 2)
+        globs = vim.re.gsub(globs, "%s+", " ")
+        local tokens = vim.split(globs, " ")
+        for _, glob in ipairs(tokens) do
+          table.insert(args, "-g")
+          table.insert(args, glob)
+        end
+      end
+
+      ---@diagnostic disable-next-line: deprecated
+      return vim.tbl_flatten {
+        args,
+        { "--color=never", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case"},
+      }
+    end,
+    entry_maker = make_entry.gen_from_vimgrep(opts),
+    cwd = opts.cwd,
+  }
+
+  pickers.new(opts, {
+    debounce = 100,
+    prompt_title = "Multi Grep",
+    finder = finder,
+    previewer = config.grep_previewer(opts),
+    sorter = require("telescope.sorters").empty(),
+  }):find()
+end
+
+M.setup = function()
+  vim.keymap.set("n", "<leader>fg", live_multigrep, { desc = "Find string in cwd (improved)" })
+end
+
+return M


### PR DESCRIPTION
This PR adds the `MultiGrep` add developed by TJ on his great video https://www.youtube.com/watch?v=xdXE1tOT-qg&t=676s

However, we have twisted this a bit to allow passing several globs instead of a single one. Example
- `foo  *.rb !test/  !db/`