### PR TITLE
(New) Where-Is-My-Test Telescope Plugin

### DIFF
--- a/lua/alex/core/keymaps.lua
+++ b/lua/alex/core/keymaps.lua
@@ -9,6 +9,7 @@ keymap.set("n", "<leader>h", ":nohl<CR>", { desc = "Clear search highlights" })
 -- Window management
 keymap.set("n", "<leader>sv", "<C-w>v", { desc = "Split window vertically" })
 keymap.set("n", "<leader>sh", "<C-w>s", { desc = "Split window horizontally" })
+keymap.set("n", "<leader>ss", "<C-w>x", { desc = "Swap windows" })
 keymap.set("n", "<leader>se", "<C-w>=", { desc = "Make splits equal size" })
 keymap.set("n", "<leader>sx", "<cmd>close<CR>", { desc = "Close current split" })
 

--- a/lua/alex/plugins/telescope.lua
+++ b/lua/alex/plugins/telescope.lua
@@ -30,5 +30,6 @@ return {
     telescope.load_extension("fzf")
 
     require("alex.plugins.telescope.multigrep").setup()
+    require("alex.plugins.telescope.where_is_my_test").setup()
   end,
 }

--- a/lua/alex/plugins/telescope/where_is_my_test.lua
+++ b/lua/alex/plugins/telescope/where_is_my_test.lua
@@ -1,0 +1,57 @@
+-- IMPROVE:
+-- [] Look for RSPEC
+
+local M = {}
+
+local from_resource_to_test = function(opts, resource_full_filename_path)
+  resource_full_filename_path = string.gsub(resource_full_filename_path, opts.cwd .. "/app/", "")
+
+  local tokens = vim.split(resource_full_filename_path, "/")
+  local filename = tokens[#tokens]
+  local base_path = tokens[1]
+
+  local pattern = string.gsub(filename, ".rb", "_test.rb")
+  local path = { "test/" .. base_path }
+
+  return pattern, path
+end
+
+local from_test_to_resource = function(opts, test_full_filename_path)
+  test_full_filename_path = string.gsub(test_full_filename_path, opts.cwd .. "/test/", "")
+
+  local tokens = vim.split(test_full_filename_path, "/")
+  local filename = tokens[#tokens]
+  local base_path = tokens[1]
+
+  local pattern = string.gsub(filename, "_test.rb", ".rb")
+  local paths = { "app/" .. base_path, base_path }
+
+  return pattern, paths
+end
+
+local guess_pattern_and_path_from = function(opts, full_filename_path)
+  if full_filename_path:match("_test.rb$") then
+    return from_test_to_resource(opts, full_filename_path)
+  else
+    return from_resource_to_test(opts, full_filename_path)
+  end
+end
+
+M.where_is_my_test = function(opts)
+  opts = opts or {}
+  opts.cwd = opts.cwd or vim.uv.cwd()
+
+  local cur_file = vim.api.nvim_buf_get_name(0)
+
+  local pattern, path = guess_pattern_and_path_from(opts, cur_file)
+
+  require("telescope.builtin").find_files {
+    find_command = { "find", path, "-type", "f", "-name", pattern },
+  }
+end
+
+M.setup = function()
+  vim.keymap.set("n", "<leader>ft", M.where_is_my_test, { desc = "Find test file" })
+end
+
+return M


### PR DESCRIPTION
With this PR we add a custom `Where is my test` telescope plugin I wrote which mimics the `RubyMine` functionality to find the test related to the ruby file we are working with.

Example of use
1. Open a ruby file
2. Hit `<leader>ft`
3. Telescope shows a window with the list of candidates tests files