### PR TITLE
(Update) Kotlin LspConfig and Treesitter Setup For AutoImport Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ $ ln -s neovim_config_v2 nvim
 - LuaLs
 - Solargraph
 
+## Telescope Extensions
+
+- Where-Is-My-Test (Ruby only)

--- a/lua/alex/plugins/lsp/lspconfig.lua
+++ b/lua/alex/plugins/lsp/lspconfig.lua
@@ -76,5 +76,22 @@ return {
         })
       end
     })
+
+    -- Kotlin LSP
+    lspconfig.kotlin_language_server.setup({
+      capabilities = capabilities,
+      settings = {
+        kotlin = {
+          codeActions = {
+            organizeImports = true,
+          },
+          compiler = {
+            jvm = {
+              target = "21",
+            },
+          },
+        },
+      },
+    })
   end,
 }

--- a/lua/alex/plugins/nvim-cmp.lua
+++ b/lua/alex/plugins/nvim-cmp.lua
@@ -78,8 +78,8 @@ return {
       -- source for autocompetion
       sources = cmp.config.sources({
         { name = "nvim_lsp" },
-        { name = "luasnip" },
         { name = "buffer" },
+        { name = "luasnip" },
         { name = "path" },
       }),
       -- configure lspkind for vs-code like pictograms in completion menu

--- a/lua/alex/plugins/treesitter.lua
+++ b/lua/alex/plugins/treesitter.lua
@@ -19,6 +19,7 @@ return {
     treesitter.setup({
       highlight = {
         enable = true,
+        additional_vim_regex_highlighting = false,
       },
       -- enable indentation
       indent = { enable = true },


### PR DESCRIPTION
With this PR we setup both the `nvim-tree` and `lspconfig` to allow Kotlin auto imports to happen:

```kotlin
# this line is added automagically after `@PostMapping` notation is written
import org.springframework.web.bind.annotation.PostMapping

@PostMapping("/api-internal/v1/foo")
```